### PR TITLE
Fix token login cache

### DIFF
--- a/iotile_analytics_core/RELEASE.md
+++ b/iotile_analytics_core/RELEASE.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+## 0.2.5
+
+- Cache session token for use with AnalyticsGroup
+
 ## 0.2.4
 
 - Fix minor bug in Datablock Mock functio
@@ -16,11 +20,11 @@
 - Add channel.fetch_source_info() to fetch data on the Project, Device or DataBlock source object.
   Option to get its properties as well.
 - Add docker/dev_dockerfile to build docker image with local changes
-  
+
 ## 0.2.1
 
 - Only get event waveforms if they exist
-  
+
 ## 0.2.0
 
 - Add CloudChannel to support multiple sources of data for creating Analysis

--- a/iotile_analytics_core/iotile_analytics/core/utilities/mock_cloud.py
+++ b/iotile_analytics_core/iotile_analytics/core/utilities/mock_cloud.py
@@ -44,6 +44,7 @@ class MockIOTileCloud(object):
             self.add_data(config_file)
 
         self.add_api("/api/v1/auth/login/", self.login)
+        self.add_api("/api/v1/account", self.account)
 
         # APIs for getting raw data
         self.add_api("/api/v1/stream/(s--[0-9\-a-f]+)/data/", self.get_stream_data)
@@ -251,6 +252,24 @@ class MockIOTileCloud(object):
         return {
             'username': user,
             'jwt': "JWT_USER"
+        }
+
+    def account(self, request):
+        self.verify_token(request)
+        return
+        {
+            "count": 1,
+            "next": null,
+            "previous": null,
+            "results": [
+                {
+                    "id": 1,
+                    "email": self.users[0],
+                    "username": self.users[0],
+                    "name": self.users[0],
+                    "slug": self.users[0]
+                }
+            ]
         }
 
     def verify_token(self, request):

--- a/iotile_analytics_core/test/test_analysis_group.py
+++ b/iotile_analytics_core/test/test_analysis_group.py
@@ -22,6 +22,17 @@ def test_session_login(water_meter):
     with pytest.raises(AuthenticationError):
         CloudSession('test@arch-iot.com', 'test2', domain=domain, verify=False)
 
+def test_token_login(water_meter):
+    """Make sure we can login successfully with a token"""
+
+    domain, _cloud = water_meter
+
+    session = CloudSession(token="JWT_USER", domain=domain, verify=False)
+
+    assert session.token == "JWT_USER"
+
+    with pytest.raises(AuthenticationError):
+        CloudSession(token="WRONG_TOKEN", domain=domain, verify=False)
 
 def test_ssl_verification(water_meter):
     """Make sure we default to verifying SSL partners."""
@@ -130,4 +141,3 @@ def test_channel_info(filter_group):
     assert device['org'] == 'test_org'
     assert device['CargoDescription'] == 'SO# 83469'
     assert device['Country'] == 'KOREA'
-

--- a/iotile_analytics_core/version.py
+++ b/iotile_analytics_core/version.py
@@ -1,1 +1,1 @@
-version = "0.2.4"
+version = "0.2.5"


### PR DESCRIPTION
Fixes the login with a token.
Will now cache properly the token, so it can be used in AnalyticsGroups as an example.
Also added testing for this part.