### PR TITLE
Allow uploading reports to iotile.cloud

### DIFF
--- a/iotile_analytics_core/RELEASE.md
+++ b/iotile_analytics_core/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## HEAD
+
+- Add support for posting files to s3 and making post requests to iotile.cloud
+  rest APIs.
+- Refactor thread pool to not create a new pool for every CloudSession instance.
+
 ## 0.4.0
 
 - Allow downloading system data as well as user data.

--- a/iotile_analytics_core/iotile_analytics/core/channels/cloud_api.py
+++ b/iotile_analytics_core/iotile_analytics/core/channels/cloud_api.py
@@ -180,12 +180,12 @@ class IOTileCloudChannel(AnalysisGroupChannel):
 
     def _count_generic_streams(self, slugs):
         resources = [self._api.stream(x).data for x in slugs]
-        ts_results = self._session.fetch_multiple(resources, message='Counting Events in Streams', page_size=1)
+        ts_results = self._session.fetch_multiple(resources, message='Counting Data in Streams', page_size=1)
 
         event_resources = [self._api.event for x in slugs]
         event_args = [{"filter": x} for x in slugs]
 
-        event_results = self._session.fetch_multiple(event_resources, event_args, message='Counting Data in Streams', page_size=1)
+        event_results = self._session.fetch_multiple(event_resources, event_args, message='Counting Events in Streams', page_size=1)
         return {slug: {'points': ts['count'], 'events': event['count']} for slug, ts, event in zip(slugs, ts_results, event_results)}
 
     def fetch_variable_types(self, slugs):

--- a/iotile_analytics_core/iotile_analytics/core/channels/cloud_api.py
+++ b/iotile_analytics_core/iotile_analytics/core/channels/cloud_api.py
@@ -6,7 +6,6 @@ from builtins import *
 from future.utils import viewitems
 
 import pandas as pd
-from iotile_cloud.stream.data import StreamData
 from iotile_cloud.api.exceptions import RestHttpBaseException
 from typedargs.exceptions import ArgumentError
 from .channel import AnalysisGroupChannel

--- a/iotile_analytics_interactive/RELEASE.md
+++ b/iotile_analytics_interactive/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## HEAD
+
+- Add support for uploading created files to iotile.cloud and linking them
+  with a device or archive.
+- Add options to analytics_host to upload files and attach them to a device that
+  the user has access to.
+
 ## 0.3.0
 
 - Add support for stream_overview report that shows detailed information about

--- a/iotile_analytics_interactive/iotile_analytics/interactive/reports/__init__.py
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/reports/__init__.py
@@ -1,4 +1,5 @@
 from .report import LiveReport
 from .branded_report import BrandedReport
+from .cloud_uploader import ReportUploader
 
-__all__ = ['LiveReport', 'BrandedReport']
+__all__ = ['LiveReport', 'BrandedReport', 'ReportUploader']

--- a/iotile_analytics_interactive/iotile_analytics/interactive/reports/__init__.py
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/reports/__init__.py
@@ -1,5 +1,6 @@
 from .report import LiveReport
 from .branded_report import BrandedReport
+from .action_report import ActionReport
 from .cloud_uploader import ReportUploader
 
-__all__ = ['LiveReport', 'BrandedReport', 'ReportUploader']
+__all__ = ['LiveReport', 'BrandedReport', 'ActionReport', 'ReportUploader']

--- a/iotile_analytics_interactive/iotile_analytics/interactive/reports/action_report.py
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/reports/action_report.py
@@ -1,0 +1,113 @@
+from collections import namedtuple
+from jinja2 import Environment
+from .branded_report import BrandedReport, APP_IOTILE_CLOUD
+
+
+ActionLink = namedtuple("ActionLink", ["link", "link_text", "short_desc", "help_text"])
+
+
+BEFORE_CONTENT = r"""
+<div class="before-content">
+    {{ before_table }}
+    {% if actions | length > 0 %}
+    <table class="action-table">
+      <col width="30%" />
+      <col width="70%" />
+      <tr class="action-table-header">
+            <th>
+                Action
+            </th>
+            <th>
+                Description
+            </th>
+        </tr>
+        <tbody>
+        {% for action in actions %}
+          <tr class="action-table-row">
+            <th>
+            <div>
+             <a href="{{action.link}}">{{ action.link_text }}</a>
+            </div>
+            {% if action.help_text is not none %}
+              <div class="action-tooltip">
+                ?
+                <span class="tooltiptext">{{ action.help_text }}</span>
+              </div>
+            {% endif %}
+            </th>
+            <th>
+                {{ action.short_desc }}
+            </th>
+          </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+    {{ after_table }}
+</div>
+"""
+
+class ActionReport(BrandedReport):
+    """A branded live report with a table of action links.
+
+    The action links are rendered in a nice table format with a link, a short
+    description and a longer description available as a tooltip on hover.
+
+    This report class is suitable for generating reports that contain
+    links to specific next-steps, such as archiving a trip or resetting
+    a device.
+
+    By default, only a table is shown.  You can customize what comes before
+    and after the table by assigning to the ``before_table`` and ``after_table``
+    members.
+
+    Args:
+        target (int): Whether we are targetting a hosted or unhosted environment
+            so that we generate the appropriate content.
+        source_info (dict): A dictionary of source information obtained from an
+            analysis group that allows us to setup the correct header and footer
+            information.
+        link_url (str): An optional direct link to the object that we are showing
+            a report about in app.iotile.cloud.  If not passed it defaults to
+            the generic start page of app.iotile.cloud.
+    """
+
+    def __init__(self, target, source_info, link_url=APP_IOTILE_CLOUD):
+        super(ActionReport, self).__init__(target, source_info, link_url)
+
+        self.before_table = ""
+        self.after_table = ""
+        self.actions = []
+
+    def add_action(self, link, target, desc, help_text=None):
+        """Add an action to the action table.
+
+        The action will be shown as a row in the table with the link
+        and the short description.  The help text will be available by
+        hovering over a ? icon after the link as a tooltip.
+
+        Args:
+            link (str): The text that should be shown in the link.
+            target (str): The link target href.
+            desc (str): A short one line description
+            help_text (str): A longer description that will be shown in a
+                tooltip when the user hovers.  If you do not specify any
+                help text, no tool tip will be shown.
+        """
+
+        action = ActionLink(target, link, desc, help_text)
+        self.actions.append(action)
+
+    def prepare_render(self):
+        """Create the action table before we render the rest of the document."""
+
+        args = {
+            "actions": self.actions,
+            "before_table": self.before_table,
+            "after_table": self.after_table
+        }
+
+        env = Environment()
+        template = env.from_string(BEFORE_CONTENT)
+
+        self.before_content = template.render(args)

--- a/iotile_analytics_interactive/iotile_analytics/interactive/reports/cloud_uploader.py
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/reports/cloud_uploader.py
@@ -115,12 +115,34 @@ class ReportUploader(object):
 
         payload = {
             'name': file_name,
-            'acl': 'public-read' if public is True else 'private'
+            'acl': 'public-read' if public is True else 'private',
+            'content_type': self._get_mime_type(file_name)
         }
 
         resource = self._api.report.generated(report_id).uploadurl
 
         return resource.url(), payload
+
+    @classmethod
+    def _get_mime_type(cls, filename):
+        _name, ext = os.path.splitext(filename)
+
+        if ext == "":
+            return 'application/octet-stream'
+
+        # Remove the .
+        ext = ext[1:]
+
+        if ext in ('jsonp', 'js'):
+            return "application/javascript"
+        elif ext in ('html', 'htm'):
+            return "text/html"
+        elif ext in ('csv',):
+            return "text/csv"
+        elif ext in ('json',):
+            return "application/json"
+
+        return "application/octet-stream"
 
     def _upload_files_to_s3(self, urls, fields, keys, files):
         bodies = []
@@ -131,7 +153,7 @@ class ReportUploader(object):
 
             file_info = {
                 'filename': key,
-                'mimetype': 'text/plain',
+                'mimetype': self._get_mime_type(key),
                 'content': file_data
             }
 

--- a/iotile_analytics_interactive/iotile_analytics/interactive/reports/cloud_uploader.py
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/reports/cloud_uploader.py
@@ -6,7 +6,6 @@ import os
 import json
 import string
 import random
-import urllib2
 from iotile_analytics.core import CloudSession
 from iotile_analytics.core.exceptions import UsageError, CloudError
 from typedargs.exceptions import ArgumentError
@@ -140,12 +139,7 @@ class ReportUploader(object):
             bodies.append(body)
             headers.append(header)
 
-        try:
-            self._session.post_multiple(urls, bodies, headers, message="Uploading report files", include_auth=False)
-        except urllib2.HTTPError as err:
-            data = err.read().decode('utf-8')
-            self._logger.exception("Exception posting S3 file: code=%d, message=%s", err.code, data)
-            raise CloudError("Error posting files to S3", error_code=err.code, message=data)
+        self._session.post_multiple(urls, bodies, headers, message="Uploading report files", include_auth=False)
 
     def _notify_upload_success(self, report_id, file_path):
         payload = {

--- a/iotile_analytics_interactive/iotile_analytics/interactive/reports/report.py
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/reports/report.py
@@ -260,11 +260,12 @@ class LiveReport(AnalysisTemplate, AnalyticsObject):
             for filename, fileinfo in viewitems(self.external_files):
                 file_path = os.path.join(datadir, filename)
 
-                all_files.append(file_path)
-
                 if self.target == self.UNHOSTED:
-                    self.render_jsonp(file_path + ".jsonp", fileinfo)
+                    file_path += ".jsonp"
+                    self.render_jsonp(file_path, fileinfo)
                 else:
                     raise UsageError("HOSTED mode for LiveReports is not yet supported")
+
+                all_files.append(file_path)
 
         return all_files

--- a/iotile_analytics_interactive/iotile_analytics/interactive/reports/report.py
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/reports/report.py
@@ -210,6 +210,9 @@ class LiveReport(AnalysisTemplate, AnalyticsObject):
                 extension or the addition of a subdirectory.
         """
 
+        # Allow subclasses to finish any preparations before we render.
+        self.prepare_render()
+
         all_files = []
 
         if output_path is None:
@@ -269,3 +272,7 @@ class LiveReport(AnalysisTemplate, AnalyticsObject):
                 all_files.append(file_path)
 
         return all_files
+
+    def prepare_render(self):
+        """Hook for any subclass that needs to setup before rendering."""
+        pass

--- a/iotile_analytics_interactive/iotile_analytics/interactive/reports/templates/report_style.css
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/reports/templates/report_style.css
@@ -23,7 +23,96 @@ li {
 
 .arch-logo {
   width: 9em;
-  height: auto;
+  height: 2.96em; /* Needs a fixed height because of bug on ie 11 with height:auto */
+}
+
+table.action-table {
+  border-spacing: 0px;
+  border-collapse: collapse;
+  border-style: solid;
+  border-width: 0px 0 2px 0;
+  border-color: black;
+  text-align: left;
+  table-layout: fixed;
+  margin: auto;
+  width:100%;
+
+  margin-top: 10px;
+  margin-bottom: 20px;
+}
+
+tr:first-child {
+  width: 200px;
+}
+
+tr.action-table-header th {
+  border-style: solid;
+  border-width: 0px 0 2px 0;
+  border-color: black;
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+tr.action-table-row th {
+  font-weight: normal;
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+.action-tooltip {
+    position: relative;
+    display: inline-block;
+    cursor: help;
+    font-weight: bold;
+}
+
+/* Tooltip text */
+.action-tooltip .tooltiptext {
+    visibility: hidden;
+    text-align: left;
+    padding: 8px;
+    border-radius: 6px;
+     
+    font-weight: normal;
+    font-size: 11pt;
+ 
+    /* Position the tooltip text - see examples below! */
+    position: absolute;
+    z-index: 1;
+
+    /* Border and background info */
+    background-color: #ddd;
+    opacity: 0.95;
+    border-color: #ccc;
+    border-width: 1px;
+    border-style: solid;
+    color: #000;
+    
+    width: 480px;
+    top: 100%;
+    left: 50%;
+    margin-top: 6px;
+    margin-left: -26px; /* Use half of the width (120/2 = 60), to center the tooltip */
+}
+
+table.action-table tbody tr th div {
+  display: inline-block;
+}
+
+.action-tooltip .tooltiptext::after {
+    content: " ";
+    position: absolute;
+    bottom: 100%;  /* At the top of the tooltip */
+    left: 5%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent #ccc transparent;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.action-tooltip:hover .tooltiptext {
+    visibility: visible;
 }
 
 .outercontainer {
@@ -99,10 +188,11 @@ li {
 
 .before-content .arrow-right {
   width: 15px;
+  height: 13px;
   margin-left: 5px;
   margin-right: 5px;
   position: relative;
-  top: 3px;
+  top: 1px;
 }
 
 .content-chart {
@@ -146,7 +236,7 @@ li {
 }
 
 .arch-systems svg {
-  width: auto;
+  width: 165px;
   height: 25px;
   padding: 0 5px;
 }

--- a/iotile_analytics_interactive/iotile_analytics/interactive/scripts/analytics_host.py
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/scripts/analytics_host.py
@@ -114,7 +114,8 @@ def build_args():
     parser.add_argument('-c', '--no-confirm', action="store_true", help="Do not confirm the analysis that you are about to perforn and prompt for parameters")
     parser.add_argument('-l', '--list', action="store_true", help="List all known analysis types without running one")
     parser.add_argument('-b', '--bundle', action="store_true", help="Bundle the rendered output into a zip file")
-    parser.add_argument('-w', '--web-push', type=str, default=None, help="Push the resulting report to iotile.cloud with this given label")
+    parser.add_argument('-w', '--web-push', action="store_true", help="Push the resulting report to iotile.cloud.")
+    parser.add_argument('--web-push-label', type=str, default=None, help="Set the label used when pushing a report to iotile.cloud")
     parser.add_argument('--web-push-org', type=str, default=None, help="Override the org given in the analysisgroup and force it to be this")
     parser.add_argument('--web-push-slug', type=str, default=None, help="Override the source slug given in the analysisgroup and force it to be this")
     parser.add_argument('-d', '--domain', default=DOMAIN_NAME, help="Domain to use for remote queries, defaults to https://iotile.cloud")
@@ -407,8 +408,8 @@ def main(argv=None):
     if len(rendered_paths) > 0:
         print("Rendered report to: %s" % rendered_paths[0])
 
-    if args.web_push is not None:
-        upload_report(args.domain, rendered_paths, args.web_push, group=group, org=args.web_push_org, slug=args.web_push_slug)
+    if args.web_push:
+        upload_report(args.domain, rendered_paths, label=args.web_push_label, group=group, org=args.web_push_org, slug=args.web_push_slug)
 
     return 0
 


### PR DESCRIPTION
## Major Enhancements

- Adds support for uploading reports to iotile.cloud
- Fixes CloudSession to reuse thread pools rather than create 10 new threads every time you create a new CloudSession (which happens somewhat often under the hood because it's assumed to be cheap)
- Adds `ActionReport` template that has a table of links with tooltips and short descriptions.  This should be used for `LiveReport` objects that are meant to provide a list of possible next steps to take after reading the report.  The action table is created automatically based on what links a subclass has added with `add_action`  calls.
- Add `prepare_render()` hook in `LiveReport` to alllow us to move initialization code out of the `__init__.py` method of all subclasses.  ActionReport uses this to relax when users can call `add_action` by moving the actual jinja2 templating of the action table to `prepare_render()`.
- Fixes CSS issues on IE 11 since IE apparently does not autoscale svg images correctly so you need to pass explicit heights and widths.

### Action Tables

Action tables are an optional convenience feature that you can use to create a table of links at the top of a report.  Each link has 4 fields and is created by calling `add_action` after subclassing from `ActionReport`:

- link_text: The actual text of the link
- link_target: What is used as the href for the link (can be a javascript function)
- short_desc: A line line description that is shown to the right of the link in the action table
- help_text: An arbitrary HTML blob that is shown in a tooltip if specified to allow for longer explanations of what an action does without making the table too wordy.  If help_text is passes, a `?` appears next to the link that shows the tool tip.

### Action Table (showing tooltip)

![image](https://user-images.githubusercontent.com/2424759/39447276-208b3aae-4c76-11e8-9e19-9507a93538e0.png)

### Action Table (without tooltip)

![image](https://user-images.githubusercontent.com/2424759/39447308-32005526-4c76-11e8-83de-3837f69016d0.png)
