### PR TITLE
Fix post_multiple on python 3.

### DIFF
--- a/iotile_analytics_core/RELEASE.md
+++ b/iotile_analytics_core/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.4.3
+
+- Fix url posting on python 3 to use correct string object in the url and
+  increase test coverage of CloudSession low-level methods.  Fix related bug
+  that prevented passing a string on python 3 as payload.
+
 ## 0.4.2
 
 - Fix password prompt in python 3 that requires a unicode string.

--- a/iotile_analytics_core/test/test_cloud_session.py
+++ b/iotile_analytics_core/test/test_cloud_session.py
@@ -1,0 +1,46 @@
+"""Tests to make sure low level CloudSession functions work as expected."""
+
+import os
+import json
+import pytest
+from iotile_analytics.core import CloudSession
+
+
+@pytest.fixture(scope='function')
+def cloud_session(mock_cloud):
+    """A base cloud session for testing low level url operations."""
+    domain, cloud = mock_cloud
+    base = os.path.dirname(__file__)
+    conf = os.path.join(base, 'data', 'test_project_watermeter.json')
+
+    cloud.add_data(os.path.join(base, 'data', 'basic_cloud.json'))
+    cloud.add_data(conf)
+    cloud.stream_folder = os.path.join(base, 'data', 'watermeter')
+
+    session = CloudSession('test@arch-iot.com', 'test', domain=domain, verify=False)
+    return session, domain
+
+
+def test_url_posting(cloud_session):
+    """Make sure the bulk url poster works."""
+
+    session, domain = cloud_session
+
+    url = domain + "/api/v1/auth/login/"
+
+    json_data = {
+        'email': "test@arch-iot.com",
+        'password': "test"
+    }
+
+    str_data = json.dumps(json_data)
+    bytes_data = json.dumps(json_data)
+
+    header = {b'content-type': b'application/json'}
+
+    results = session.post_multiple([url, url, url], [json_data, str_data, bytes_data],
+                                    [{}, header, header], include_auth=False)
+
+    for result in results:
+        data = json.loads(result)
+        assert data == {"username": "test@arch-iot.com", "jwt": "JWT_USER"}

--- a/iotile_analytics_core/version.py
+++ b/iotile_analytics_core/version.py
@@ -1,1 +1,1 @@
-version = "0.4.2"
+version = "0.4.3"


### PR DESCRIPTION
Fixes a unicode encoding behavior difference on python 2 and 3 in the urlopen function that requires a preencoded string on python 2 but cannot accept a preencoded string on python 3.

Also adds basic test coverage of the `post_multiple` function on iotile_analytics to catch this behavior in the future.

Closes #47