### PR TITLE
Resolve python 3 request header issue

### DIFF
--- a/iotile_analytics_core/iotile_analytics/core/session.py
+++ b/iotile_analytics_core/iotile_analytics/core/session.py
@@ -11,6 +11,7 @@ import sys
 import logging
 from threading import Lock
 from multiprocessing.pool import ThreadPool
+from future.utils import iteritems
 
 # For some reason using the future input = raw_input patch in builtins
 # does not work on jupyter so fall back to this manual patch.
@@ -398,6 +399,8 @@ class CloudSession(object):
             # See: https://github.com/iotile/iotile_analytics/issues/47
             if sys.version_info.major < 3:
                 url = url.encode('utf-8')
+            else:
+                headers = {key.decode('utf-8'): val.decode('utf-8') for key, val in iteritems(headers)}
 
             req = Request(url, data, headers=headers)
 

--- a/iotile_analytics_interactive/iotile_analytics/interactive/reports/cloud_uploader.py
+++ b/iotile_analytics_interactive/iotile_analytics/interactive/reports/cloud_uploader.py
@@ -123,7 +123,7 @@ class ReportUploader(object):
         payloads = [x[1] for x in url_infos]
 
         resp_list = self._session.post_multiple(urls, payloads, message="Getting file upload authorization", include_auth=True)
-        decoded_resps = [json.loads(resp.decode('utf-8')) for resp in resp_list]
+        decoded_resps = [json.loads(resp) for resp in resp_list]
         urls = [x['url'] for x in decoded_resps]
         fields = [x['fields'] for x in decoded_resps]
         return urls, fields
@@ -243,7 +243,7 @@ def encode_multipart(fields, files, boundary=None):
     body = b'\r\n'.join(lines)
 
     headers = {
-        b'Content-Type': b'multipart/form-data; boundary={0}'.format(boundary.encode('utf-8'))
+        b'Content-Type': 'multipart/form-data; boundary={0}'.format(boundary).encode('utf-8')
     }
 
     return (body, headers)


### PR DESCRIPTION
It looks like its important to use native strings on both python 3 and python 2.  Python 2 urllib2 does not like `unicode` objects for urls and python 3 does not like bytes objects for headers.

Closes #50 