### PR TITLE
Fix envelope calculation when logarithmic bucket spacing is used

### DIFF
--- a/iotile_analytics_core/RELEASE.md
+++ b/iotile_analytics_core/RELEASE.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.4.5
+
+- Fix envelope calculation function to not have numerical instability when
+  working with logarithmic bin spacing.
+
 ## 0.4.4
 
 - Fix another issue uploading reports on python 3.  Makes sure to use

--- a/iotile_analytics_core/iotile_analytics/core/utilities/envelope.py
+++ b/iotile_analytics_core/iotile_analytics/core/utilities/envelope.py
@@ -55,6 +55,10 @@ def envelope(*arrays, **kwargs):
     else:
         bins = np.geomspace(d_min, d_max, num_bins+1)
 
+    # Make sure there are no roundoff errors so that every element in the
+    # envelope domain is contained inside the bins.
+    bins[0] = d_min
+    bins[-1] = d_max
 
     env_min = np.zeros_like(bins[1:])
     env_max = np.zeros_like(bins[1:])

--- a/iotile_analytics_core/version.py
+++ b/iotile_analytics_core/version.py
@@ -1,1 +1,1 @@
-version = "0.4.4"
+version = "0.4.5"


### PR DESCRIPTION
Previously, accumulated numerical error could make the upper bin edge not properly cover the passed in domain, resulting in an `IndexError`.  This fixes it by making sure the first and last bins are exactly what the user passed in.