### PR TITLE
Add support for device data masks

### DIFF
--- a/iotile_analytics_core/RELEASE.md
+++ b/iotile_analytics_core/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.4.6
+
+- Add support for Device Data Masks. If user sets a device mask on IOTile Cloud,
+  any analysis will automatically respect that mask and not get any data outside
+  the mask's datetime range.
+
 ## 0.4.5
 
 - Fix envelope calculation function to not have numerical instability when

--- a/iotile_analytics_core/iotile_analytics/core/channels/cloud_api.py
+++ b/iotile_analytics_core/iotile_analytics/core/channels/cloud_api.py
@@ -219,7 +219,7 @@ class IOTileCloudChannel(AnalysisGroupChannel):
 
         try:
             resource = self._api.event
-            data = self._session.fetch_all(resource, page_size=1000, message="Downloading Events", filter=slug)
+            data = self._session.fetch_all(resource, page_size=1000, message="Downloading Events", filter=slug, mask=1)
 
             dt_index = pd.to_datetime([x['timestamp'] for x in data])
             extra_data = [x['extra_data'] for x in data]
@@ -306,7 +306,7 @@ class IOTileCloudChannel(AnalysisGroupChannel):
             return StreamSeries([float(x[1]) for x in data], index=dt_index)
 
         resource = self._api.data
-        raw_json = self._session.fetch_all(resource, page_size=10000, message="Downloading Data", filter=slug)
+        raw_json = self._session.fetch_all(resource, page_size=10000, message="Downloading Data", filter=slug, mask=1)
 
         dt_index = pd.to_datetime([x['timestamp'] for x in raw_json])
         data = [x['int_value'] for x in raw_json]

--- a/iotile_analytics_core/version.py
+++ b/iotile_analytics_core/version.py
@@ -1,1 +1,1 @@
-version = "0.4.5"
+version = "0.4.6"


### PR DESCRIPTION
Closes #63 

I was considering making this an option, but cannot really see why would anybody want to ignore the mask. If somebody wants to ignore the mask, they should just remove the mask from IOTile Cloud, as that is easy enough.