### PR TITLE
Fix envelope_update function

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ This package requires the following standard python data analysis packages:
 
 - numpy
 - pandas
-- matplotlib
 
 They are installed automatically when you install `iotile_anlytics` but if you
 are running on Windows, you may want to download a prebuilt python distribution

--- a/iotile_analytics_core/RELEASE.md
+++ b/iotile_analytics_core/RELEASE.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.5.2
+
+- Fix envelope_update function to properly handle readings that are out of 
+  the domain of the envelope being computed.
+
 ## 0.5.1
 
 - Properly suppress warning if you choose verify=False during testing to disable

--- a/iotile_analytics_core/iotile_analytics/core/utilities/envelope.py
+++ b/iotile_analytics_core/iotile_analytics/core/utilities/envelope.py
@@ -193,7 +193,7 @@ def envelope_update(state, array):
     for arr_i, i in enumerate(indices):
         val = array[arr_i, 1]
 
-        if i == len(envelope):
+        if i == len(envelope) - 1:
             continue
 
         if np.isnan(envelope[i + 1, 2]) or val > envelope[i + 1, 2]:

--- a/iotile_analytics_core/test/test_envelope.py
+++ b/iotile_analytics_core/test/test_envelope.py
@@ -118,3 +118,10 @@ def test_bin_edges():
     assert out2_left[:, 0] == pytest.approx(bins[:-1])
     assert out2_right[:, 0] == pytest.approx(bins[1:])
     assert out2_center[:, 0] == pytest.approx((bins[1:] + bins[:-1]) / 2.0)
+
+    # Make sure that data outside of the bins is rejected without error
+    state = envelope_create(x_vals[0], x_vals[-1], bin_count=10, bin_mark='left')
+    envelope_update(state, in1)
+    envelope_update(state, in2)
+    envelope_update(state, np.array([[11, 5]]))
+    out2_left = envelope_finish(state)

--- a/iotile_analytics_core/version.py
+++ b/iotile_analytics_core/version.py
@@ -1,1 +1,1 @@
-version = "0.5.1"
+version = "0.5.2"

--- a/iotile_analytics_interactive/RELEASE.md
+++ b/iotile_analytics_interactive/RELEASE.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.5.2
+
+- Pin bokeh version until we are compatible with bokeh 1.0.0
+
 ## 0.5.1
 
 - Add support for passing an iotile.cloud token on the command line using 

--- a/iotile_analytics_interactive/setup.py
+++ b/iotile_analytics_interactive/setup.py
@@ -12,7 +12,7 @@ setup(
     license="LGPLv3",
     install_requires=[
         "iotile-analytics-core >= 0.1.0",
-        "bokeh >= 0.12.15"
+        "bokeh == 0.12.16"
     ],
     entry_points={
         'console_scripts': ['analytics-host = iotile_analytics.interactive.scripts.analytics_host:cmdline_main'],

--- a/iotile_analytics_interactive/version.py
+++ b/iotile_analytics_interactive/version.py
@@ -1,1 +1,1 @@
-version = "0.5.1"
+version = "0.5.2"

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,4 +1,4 @@
-bokeh >= 0.12.5
+bokeh == 0.12.16
 sphinx >= 1.7.2
 twine==1.11.0
 better-apidoc


### PR DESCRIPTION
There was an off-by-one error in `envelope_update` that caused it to break if data was specified outside its envelope-calculation domain.

Closes #72