### PR TITLE
Fetching streams and events within a time range

### DIFF
--- a/iotile_analytics_core/iotile_analytics/core/channels/cloud_api.py
+++ b/iotile_analytics_core/iotile_analytics/core/channels/cloud_api.py
@@ -330,16 +330,7 @@ class IOTileCloudChannel(AnalysisGroupChannel):
 
         with ProgressBar(1, "Fetching %s" % slug, leave=False) as prog:
             if range_payload:
-                if range_payload.get('start') and range_payload.get('end'):
-                    raw_data = self._api.df.get(filter=slug, format='csv', mask=1,
-                                                start=range_payload.get('start'),
-                                                end=range_payload.get('end'))
-                elif range_payload.get('start'):
-                    raw_data = self._api.df.get(filter=slug, format='csv', mask=1,
-                                                start=range_payload.get('start'))
-                elif range_payload.get('end'):
-                    raw_data = self._api.df.get(filter=slug, format='csv', mask=1,
-                                                end=range_payload.get('end'))
+                raw_data = self._api.df.get(filter=slug, format='csv', mask=1, **range_payload)
             else:
                 raw_data = self._api.df.get(filter=slug, format='csv', mask=1)
 

--- a/iotile_analytics_core/iotile_analytics/core/group.py
+++ b/iotile_analytics_core/iotile_analytics/core/group.py
@@ -19,6 +19,7 @@ from typedargs.exceptions import ArgumentError
 from .exceptions import CloudError
 from .session import CloudSession
 from .channels import IOTileCloudChannel
+from utilities import get_utc_ts
 
 
 class AnalysisGroup(object):
@@ -186,7 +187,7 @@ class AnalysisGroup(object):
 
         return found[0]
 
-    def fetch_stream(self, slug_or_name, allow_empty=False):
+    def fetch_stream(self, slug_or_name, allow_empty=False, start=None, end=None):
         """Fetch data from a stream by its slug or name.
 
         For example say you have the following stream in this analysis project:
@@ -198,6 +199,16 @@ class AnalysisGroup(object):
          - Temperature
          - s--0000-0011--0000-0000-0000-0222--5001
 
+        This method also supports fetching entries between specific start and end timestamps.
+        By default the start and end values set by this method are None. If either of the
+        options is ommitted, then the fetched stream entries are bound only by the other option.
+
+        If both the options are specified, then they are first converted to valid
+        ISO formatted datetime strings in UTC, and then passed to the data APIs for querying.
+
+        If the string represented timestamps are not datetime compatible, then an appropriate
+        error is thrown.
+
         Args:
             slug_or_name (str): The stream that we want to fetch.  This
                 can be a partial match to a full stream slug or name so long
@@ -206,14 +217,20 @@ class AnalysisGroup(object):
             allow_empty (bool): Allow fetching an empty stream.  If allow_empty is False or
                 not passed, an ArgumentError will be raised if the target stream is empty.
 
+            start (str or datetime): A string or a datetime representing the start time for
+            datapoint fetch. If not specified, this defaults to None
+
+            end (str or datetime): A string or a datetime representing the end time for datapoint
+            fetch. If not specified, this defaults to None
+
         Returns:
             StreamSeries: A pandas DataFrame subclass containing the data points as columns.
                 The index of the dataframe is time in UTC.
         """
 
-        slug = self.find_stream(slug_or_name, include_empty=allow_empty)
+        slug = self.find_stream(include_empty=allow_empty)
         stream = self.streams[slug]
-        raw = self._channel.fetch_datapoints(slug)
+        raw = self._channel.fetch_datapoints(slug, start=get_utc_ts(start), end=get_utc_ts(end))
 
         if stream is not None:
             raw.set_stream(stream)

--- a/iotile_analytics_core/iotile_analytics/core/group.py
+++ b/iotile_analytics_core/iotile_analytics/core/group.py
@@ -19,7 +19,7 @@ from typedargs.exceptions import ArgumentError
 from .exceptions import CloudError
 from .session import CloudSession
 from .channels import IOTileCloudChannel
-from utilities import get_utc_ts
+from .utilities import get_utc_ts
 
 
 class AnalysisGroup(object):

--- a/iotile_analytics_core/iotile_analytics/core/group.py
+++ b/iotile_analytics_core/iotile_analytics/core/group.py
@@ -228,7 +228,7 @@ class AnalysisGroup(object):
                 The index of the dataframe is time in UTC.
         """
 
-        slug = self.find_stream(include_empty=allow_empty)
+        slug = self.find_stream(slug_or_name, include_empty=allow_empty)
         stream = self.streams[slug]
         raw = self._channel.fetch_datapoints(slug, start=get_utc_ts(start), end=get_utc_ts(end))
 

--- a/iotile_analytics_core/iotile_analytics/core/utilities/__init__.py
+++ b/iotile_analytics_core/iotile_analytics/core/utilities/__init__.py
@@ -3,5 +3,7 @@
 from .domain import find_domain, combine_domains
 from .envelope import envelope, envelope_create, envelope_update, envelope_finish
 from .aggregator import TimeseriesSelector
+from .date_utils import get_utc_ts
 
-__all__ = ['find_domain', 'combine_domains', 'envelope', 'TimeseriesSelector', 'envelope_create', 'envelope_update', 'envelope_finish']
+__all__ = ['find_domain', 'combine_domains', 'envelope', 'TimeseriesSelector', 'envelope_create',
+           'envelope_update', 'envelope_finish', 'get_utc_ts']

--- a/iotile_analytics_core/iotile_analytics/core/utilities/date_utils.py
+++ b/iotile_analytics_core/iotile_analytics/core/utilities/date_utils.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+from dateutil import parser
+import pytz
+from typedargs.exceptions import ArgumentError
+
+def convert_str_to_dt(str_dt):
+    """Convert string to UTC datetime"""
+    dt = parser.parse(str_dt)
+    return dt
+
+def convert_or_force_utc(dt):
+    """Convert timezone to UTC or force UTC to incoming datetime
+
+    Args:
+        dt (datetime): A tz-aware or tz-naive datetime
+
+    Returns:
+        dt_utc (datetime): UTC datetime
+    """
+    if dt.tzinfo:
+        dt_utc = dt.astimezone(pytz.timezone('UTC'))
+    else:
+        dt_utc = pytz.timezone('UTC').localize(dt)
+
+    return dt_utc
+
+def formatted_ts(dt):
+    return dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+def get_utc_ts(str_or_dt):
+    """Get UTC timestamp in ISO format.
+
+    Args:
+        str_or_dt (str or datetime): A string representing a valid datetime or
+            datetime-compatible string
+
+    Returns:
+        ts (str): UTC timestamp in ISO format
+    """
+    if str_or_dt is None:
+        return None
+
+    if not isinstance(str_or_dt, (str, datetime)):
+        raise ArgumentError("""Incoming argument is not a valid string or a datetime""",
+                            str_or_dt=str_or_dt, type=type(str_or_dt))
+
+    if isinstance(str_or_dt, datetime):
+        ts = convert_or_force_utc(str_or_dt)
+        return formatted_ts(ts)
+
+    if isinstance(str_or_dt, str):
+        ts = convert_str_to_dt(str_or_dt)
+        ts = convert_or_force_utc(ts)
+        return formatted_ts(ts)
+
+    return None

--- a/iotile_analytics_core/test/test_analysis_group.py
+++ b/iotile_analytics_core/test/test_analysis_group.py
@@ -4,6 +4,8 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 from builtins import *
 
+from datetime import datetime
+
 import pytest
 import pandas as pd
 from typedargs.exceptions import ArgumentError
@@ -173,3 +175,18 @@ def test_hidden_streams(filter_group, with_system):
 
     data = withsys_group.fetch_stream('5c00')
     assert len(data) == 4
+
+
+def test_stream_download_with_timerange(filter_group):
+    """Make sure we can download streams from an analysis group with a given time range."""
+
+    now = datetime.now()
+
+    data = filter_group.fetch_stream('5001', start=now, end=now)
+    assert len(data) == 0
+
+    assert isinstance(data, StreamSeries)
+    assert set(data.available_units) == set(['Liters', 'Gallons', 'Cubic Meters', 'Acre Feet'])
+
+    outL = data.convert('Liters')
+    outG = data.convert('Gallons')


### PR DESCRIPTION
This PR adds the long-desired feature of fetching `stream data`, `events` and `raw_events` by bounding them within specific `start` and `end` points, if required.

Currently, `AnalysisGroup`'s `fetch_stream()`, `fetch_events()` and `fetch_raw_events()` download **all** the data associated with the input slug. This feature is fine with the slug corresponds to a specific device or a datablock.

There is a lot of **good** functionality implemented into `cloud_api` - persistent connection, concurrent fetching of resources, HTTP/REST error handling, fetching of API resources by object etc. 

To use all of this functionality implemented into `AnalysisGroup` and `IOTileCloudChannel` for other applications - specifically `arch_factory`'s machine models, fetch methods in `AnalysisGroup` need to take time range into account. This is to prevent DB loading on the cloud.

Since `AnalysisGroup` and its methods are used in several reports - this change could be disruptive - so enabling this by retaining the default behavior of the `fetch_*` methods. 

#### What's in this PR:
- Updated `fetch_stream()` method to allow `start` and `end` specification. They are set to `None` by default. The input to these arguments could be a valid `datetime`-compatible string or a `datetime` object

- `date_utils.py` `get_utc_ts` - that accepts `start`, `end` arguments and creates a valid, ISO-format UTC timestamp from the arguments. If timezone information is not present in the arguments, then UTC timezone is forced

- Updated implementation of `fetch_datapoints()` in `IOTileCloudChannel` to account for `start` and `end` to `df` and `data` API

#### TODO:
- Fix test failures and add robust tests
- Update `fetch_events` and `fetch_raw_events` methods